### PR TITLE
Update Dockerfiles to use openjdk:25

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,10 @@
-FROM openjdk:17-jdk-alpine3.14
+FROM openjdk:25
 
 COPY . /opt/app/
 WORKDIR /opt/app
 
-RUN apk add curl
+RUN apt-get update && apt-get install -y curl
+
 RUN chmod +x gradlew
 RUN ./gradlew --no-daemon --warning-mode all buildFatJar
 

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,9 +1,10 @@
-FROM openjdk:17-jdk-alpine3.14
+FROM openjdk:25
 
 COPY . /opt/app/
 WORKDIR /opt/app
 
-RUN apk add curl
+RUN apt-get update && apt-get install -y curl
+
 RUN chmod +x gradlew
 RUN ./gradlew --no-daemon --warning-mode all buildFatJar
 


### PR DESCRIPTION
Update Dockerfiles to use `openjdk:25` instead of `openjdk:17-jdk-alpine3.14`.

* **api/Dockerfile**
  - Change the base image from `openjdk:17-jdk-alpine3.14` to `openjdk:25`.
  - Remove the `RUN apk add curl` line.
  - Add `RUN apt-get update && apt-get install -y curl` after `WORKDIR /opt/app`.

* **landing/Dockerfile**
  - Change the base image from `openjdk:17-jdk-alpine3.14` to `openjdk:25`.
  - Remove the `RUN apk add curl` line.
  - Add `RUN apt-get update && apt-get install -y curl` after `WORKDIR /opt/app`.

